### PR TITLE
Add jsx and tsx to languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ require 'cmp'.setup {
 
 ### filetypes (type: string[])
 
-***Default***: `{ 'html', 'xml', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less', 'heex' }`
+***Default***: `{ 'html', 'xml', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less', 'heex', 'tsx', 'jsx' }`
 
  Filetypes, including embedded filetypes, for which to enable this source.
 

--- a/lua/cmp_emmet_vim/init.lua
+++ b/lua/cmp_emmet_vim/init.lua
@@ -7,7 +7,19 @@ local fn = vim.fn
 
 ---@type cmp_emmet_vim.Options
 local defaults = {
-    filetypes = { 'html', 'xml', 'typescriptreact', 'javascriptreact', 'css', 'sass', 'scss', 'less', 'heex' },
+    filetypes = {
+        'html',
+        'xml',
+        'typescriptreact',
+        'javascriptreact',
+        'css',
+        'sass',
+        'scss',
+        'less',
+        'heex',
+        'tsx',
+        'jsx',
+    },
 }
 
 local source = {}


### PR DESCRIPTION
jsx and tsx are the string names for treesitter

Re-opening this one: https://github.com/dcampos/cmp-emmet-vim/pull/3